### PR TITLE
Added: print that states how many tracks are still to be processed + Fixed: tract title encoding caused crash on prints

### DIFF
--- a/bandcamp_dl/BandcampDownloader.py
+++ b/bandcamp_dl/BandcampDownloader.py
@@ -59,11 +59,13 @@ class BandcampDownloader():
             dirname = self.create_directory(filename)
 
             if not self.overwrite and os.path.isfile(filename):
-                print "Skipping track {} - {} as it's already downloaded, use --overwrite to overwrite existing files".format(track['track'], track['title'])
+                re_encoded_track_title = track['title'].encode('utf-8')
+                print "Skipping track {} - {} as it's already downloaded, use --overwrite to overwrite existing files".format(track['track'], re_encoded_track_title)
                 continue
 
             if not track.get('url'):
-                print "Skipping track {} - {} as it is not available".format(track['track'], track['title'])
+                re_encoded_track_title = track['title'].encode('utf-8')
+                print "Skipping track {} - {} as it is not available".format(track['track'], re_encoded_track_title)
                 continue
 
             try:

--- a/bandcamp_dl/BandcampDownloader.py
+++ b/bandcamp_dl/BandcampDownloader.py
@@ -53,7 +53,7 @@ class BandcampDownloader():
                 "track": track['track'],
                 "date": album['date']
             }
-            print("Fetching track " + str(track_index+1) + "of " + str(len(album['tracks']))
+            print("Accessing track " + str(track_index+1) + " of " + str(len(album['tracks'])))
 
             filename = self.template_to_path(track_meta)
             dirname = self.create_directory(filename)

--- a/bandcamp_dl/BandcampDownloader.py
+++ b/bandcamp_dl/BandcampDownloader.py
@@ -45,7 +45,7 @@ class BandcampDownloader():
 
     def download_album(self, album):
 
-        for track in album['tracks']:
+        for track_index,track in enumerate(album['tracks']):
             track_meta = {
                 "artist": album['artist'],
                 "album": album['title'],
@@ -53,6 +53,7 @@ class BandcampDownloader():
                 "track": track['track'],
                 "date": album['date']
             }
+            print("Fetching track " + str(track_index+1) + "of " + str(len(album['tracks']))
 
             filename = self.template_to_path(track_meta)
             dirname = self.create_directory(filename)


### PR DESCRIPTION
Feature add: 
- added a "Accessing track 1 of N" message to the album download function. So the user knows how many are still to come, etc.

Fix:
- spotted a bug that caused a crash on the prints, when the track title had german chars such as ä, added utf-8 encoding before the print and seems to work fine and no crash. 
