### PR TITLE
Changed hardcoded python to env PATH

### DIFF
--- a/bandcamp_dl/bandcamp_dl.py
+++ b/bandcamp_dl/bandcamp_dl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """bandcamp-dl
 Usage:

--- a/bandcamp_dl/bandcamp_dl.py
+++ b/bandcamp_dl/bandcamp_dl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """bandcamp-dl
 Usage:


### PR DESCRIPTION
Uses env PATH to find which python to use instead of the hardcoded `/usr/bin/python`
- More flexibility
- No problem on non-standard filesystem layout
- Pythonic way of doing things
