### PR TITLE
Lyrics saved as USTL tag inside MP3

### DIFF
--- a/bandcamp_dl/Bandcamp.py
+++ b/bandcamp_dl/Bandcamp.py
@@ -58,7 +58,7 @@ class Bandcamp:
         new_track['duration'] = track['duration']
         new_track['track'] = track['track_num']
         new_track['title'] = track['title']
-        if track['lyrics']:
+        if track['lyrics'] != 'null':
             track['lyrics'] = track['lyrics'].encode(encoding='UTF-8',errors='ignore')
             new_track['lyrics'] = track['lyrics'].replace('\\r\\n', '\n')
 

--- a/bandcamp_dl/Bandcamp.py
+++ b/bandcamp_dl/Bandcamp.py
@@ -58,6 +58,9 @@ class Bandcamp:
         new_track['duration'] = track['duration']
         new_track['track'] = track['track_num']
         new_track['title'] = track['title']
+        if track['lyrics']:
+            track['lyrics'] = track['lyrics'].encode(encoding='UTF-8',errors='ignore')
+            new_track['lyrics'] = track['lyrics'].replace('\\r\\n', '\n')
 
         return new_track
 

--- a/bandcamp_dl/BandcampDownloader.py
+++ b/bandcamp_dl/BandcampDownloader.py
@@ -51,9 +51,11 @@ class BandcampDownloader():
                 "album": album['title'],
                 "title": track['title'],
                 "track": track['track'],
-                "lyrics": track['lyrics'],
                 "date": album['date']
             }
+            if 'lyrics' in track.keys():
+                track_meta['lyrics'] = track['lyrics'];
+
             print("Accessing track " + str(track_index+1) + " of " + str(len(album['tracks'])))
 
             filename = self.template_to_path(track_meta)
@@ -105,8 +107,9 @@ class BandcampDownloader():
         audio["date"] = meta['date']
         audio.save()
 
-        audio = ID3(filename)
-        audio[u"USLT::'eng'"] = (USLT(encoding=3, lang=u'eng', desc=u'', text=meta['lyrics']))
-        audio.save(filename)
+        if 'lyrics' in meta.keys():
+            audio = ID3(filename)
+            audio[u"USLT::'eng'"] = (USLT(encoding=3, lang=u'eng', desc=u'', text=meta['lyrics']))
+            audio.save(filename)
 
         print "Done encoding . . . "

--- a/bandcamp_dl/BandcampDownloader.py
+++ b/bandcamp_dl/BandcampDownloader.py
@@ -1,7 +1,7 @@
 import wgetter
 
 from mutagen.mp3 import MP3
-from mutagen.id3 import TIT2
+from mutagen.id3 import TIT2, ID3, USLT
 from mutagen.easyid3 import EasyID3
 import os
 from slugify import slugify
@@ -51,6 +51,7 @@ class BandcampDownloader():
                 "album": album['title'],
                 "title": track['title'],
                 "track": track['track'],
+                "lyrics": track['lyrics'],
                 "date": album['date']
             }
             print("Accessing track " + str(track_index+1) + " of " + str(len(album['tracks'])))
@@ -103,5 +104,9 @@ class BandcampDownloader():
         audio["album"] = meta['album']
         audio["date"] = meta['date']
         audio.save()
+
+        audio = ID3(filename)
+        audio[u"USLT::'eng'"] = (USLT(encoding=3, lang=u'eng', desc=u'', text=meta['lyrics']))
+        audio.save(filename)
 
         print "Done encoding . . . "


### PR DESCRIPTION
#49

Thanks @iheanyi for misunderstanding what I was trying to say.. this way you pushed me to dig this in :)
I hope you will consider this pull request because I think lyrics are really important for a lot of non-native English speakers and for those who wants to backup their music completely, with the booklet too.

Ok not so many mp3 player use this tag but i like to think that this will be an increasing practice. and developers have to push it

You can check the result with MusicBrainz Picard
If you copy the lyrics field in the tags and paste it on atom -for example- you can see that "newlines" are correct.

Cheers!

_UPDATE: now the code is ok when there is no lyrics too_
