### PR TITLE
ID3 Data Windows Explorer Compatibility

### DIFF
--- a/bandcamp_dl/BandcampDownloader.py
+++ b/bandcamp_dl/BandcampDownloader.py
@@ -94,7 +94,7 @@ class BandcampDownloader():
 
         audio = MP3(filename)
         audio["TIT2"] = TIT2(encoding=3, text=["title"])
-        audio.save()
+        audio.save(filename=None,v1=2)
 
         audio = EasyID3(filename)
         audio["tracknumber"] = meta['track']


### PR DESCRIPTION
This is a new pull request with the same change as previously. I downloaded and tested the change on an up to date branch of bandcamp-dl and  it functioned properly in Windows 10. The old pull request had gotten really messed up somehow. I think that the branch fell out of date.

>  Windows Explorer and Media Player cannot read ID3v2 data without first having ID3v1 data present. This makes it necessary to first enable ID3v1 if it was not already enabled on the files (which apparently Bandcamp does not)
> 
> It's probably easy to miss this on any reasonable media player or Linux ;)
> 
> More syntax info from 
> http://mutagen.readthedocs.org/en/latest/api/id3.html#mutagen.id3.ID3.save
> 
> Original solution from post on https://code.google.com/p/mutagen/wiki/Tutorial
> 
> > Comment by jehoshu...@gmail.com, Oct 4, 2011
> > After many hours . . .
> > I discovered why on save() the information disappears in Windows Explorer and Media Player . . .
> > . . . Windows Explorer and Media Player only read, and mutagen does NOT write, ID3v1 tags!
> > And as far as I can tell from the LIMITED documentation, mutagen will READ BUT NOT WRITE ID3v1  tags.
> > I further discovered, while playing with WINAMP, that it is possible to have BOTH ID3v1 and ID3v2 tags in a file, BUT Windows Explorer and Media Player require the ID3v1 tags to come first!
> > But there's no way to explicitly ensure that mutagen follows this requirement.
> > Does anybody know ID3v1 well enough to dive into the source code and fix this?
> > I'm using Windows 7, Python 2.7, Mutagen 1.20. I really hope this helps someone avoid spending painful amounts time!
