### PR TITLE
bugfix issue #105

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea
 *.iml
 *.xml
 bandcamp_dl/asyncdownloader.py

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -100,6 +100,8 @@ class BandcampDownloader:
 
             if 'lyrics' in track.keys() and self.lyrics is not False:
                 track_meta['lyrics'] = track['lyrics']
+            else:
+                track_meta['lyrics'] = 'lyrics unavailable'
 
             self.num_tracks = len(album['tracks'])
             self.track_num = track_index + 1


### PR DESCRIPTION
If lyrics are missing from the page but are requested with the `--embed-lyrics` option, then lyrics tag will contain 'lyrics unavailable' string.