### PR TITLE
Fix for #123 - ensures lockfile deleted from base directory

### DIFF
--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -201,8 +201,8 @@ class BandcampDownloader:
             if skip is False:
                 self.write_id3_tags(filepath, track_meta)
 
-        if os.path.isfile("{}.not.finished".format(__version__)):
-            os.remove("{}.not.finished".format(__version__))
+        if os.path.isfile("{}/{}.not.finished".format(self.directory,__version__)):
+            os.remove("{}/{}.not.finished".format(self.directory,__version__))
 
         # Remove album art image as it is embedded
         if self.embed_art:

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -201,8 +201,8 @@ class BandcampDownloader:
             if skip is False:
                 self.write_id3_tags(filepath, track_meta)
 
-        if os.path.isfile("{}/{}.not.finished".format(self.directory,__version__)):
-            os.remove("{}/{}.not.finished".format(self.directory,__version__))
+        if os.path.isfile("{}/{}.not.finished".format(self.directory, __version__)):
+            os.remove("{}/{}.not.finished".format(self.directory, __version__))
 
         # Remove album art image as it is embedded
         if self.embed_art:


### PR DESCRIPTION
__main__ created the file in base-dir but bandcampDownloader checked for it in the working
directory. As bandcampDownloader has the base-dir, this commit uses that to point in
the expected place.