### PR TITLE
#125 rfc- enable genre in template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,7 @@ tokens:
 -  ``album``: The album name.
 -  ``track``: The track number.
 -  ``title``: The track title.
+-  ``genres``: The genre tags of the album.
 
 The default template is: ``%{artist}/%{album}/%{track} - %{title}``.
 

--- a/bandcamp_dl/bandcamp.py
+++ b/bandcamp_dl/bandcamp.py
@@ -13,6 +13,13 @@ from bandcamp_dl.__init__ import __version__
 class Bandcamp:
     def __init__(self):
         self.headers = {'User-Agent': 'bandcamp-dl/{} (https://github.com/iheanyi/bandcamp-dl)'.format(__version__)}
+        """ the list of top level genres on bandcamp """
+        self.genres = ["rock", "alternative", "hip-hop/rap",\
+        "electronic", "pop", "acoustic", "folk", "punk", "metal",\
+        "experimental", "ambient", "r&b/soul", "jazz", "blues",\
+        "country", "funk", "reggae", "devotional", "soundtrack",\
+        "classical", "latin", "world", "kids", "comedy", "audiobooks",\
+        "podcasts", "spoken word"]
 
     def parse(self, url: str, art: bool=True, lyrics: bool=False, debugging: bool=False) -> dict or None:
         """Requests the page, cherry picks album info
@@ -41,6 +48,7 @@ class Bandcamp:
         album_json = json.loads(bandcamp_json[0])
         embed_json = json.loads(bandcamp_json[1])
         page_json = json.loads(bandcamp_json[2])
+        genres_of_album = self.get_genre_tags()
         logging.debug(" BandcampJSON generated..")
 
         logging.debug(" Generating Album..")
@@ -67,7 +75,8 @@ class Bandcamp:
             "label": label,
             "full": False,
             "art": "",
-            "date": str(dt.strptime(album_release, "%d %b %Y %H:%M:%S GMT").year)
+            "date": str(dt.strptime(album_release, "%d %b %Y %H:%M:%S GMT").year),
+            "genres": genres_of_album
         }
 
         artist_url = album_json['url'].rpartition('/album/')[0]
@@ -159,3 +168,20 @@ class Bandcamp:
             return url
         except None:
             pass
+
+    def get_genre_tags(self) -> str:
+        """ comma separated tags that correspond to genres """
+        album_tag_links = self.soup.find_all("a", class_="tag")
+        album_tags = []
+        for link in album_tag_links:
+            candidate = str(link.string)
+            if tag in self.genres and candidate not in album_tags:
+                album_tags.append(candidate)
+        genres_as_csv = ""
+        for genre in album_tags:
+            genres_as_csv += genre +","
+        if len(genres_as_csv) > 1:
+            genres_as_csv = genres_as_csv[:-1]
+        else:
+            genres_as_csv = "none"
+        return genres_as_csv

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -201,8 +201,8 @@ class BandcampDownloader:
             if skip is False:
                 self.write_id3_tags(filepath, track_meta)
 
-        if os.path.isfile("{}.not.finished".format(__version__)):
-            os.remove("{}.not.finished".format(__version__))
+        if os.path.isfile("{}/{}.not.finished".format(self.directory,__version__)):
+            os.remove("{}/{}.not.finished".format(self.directory,__version__))
 
         # Remove album art image as it is embedded
         if self.embed_art:

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -201,8 +201,8 @@ class BandcampDownloader:
             if skip is False:
                 self.write_id3_tags(filepath, track_meta)
 
-        if os.path.isfile("{}/{}.not.finished".format(self.directory,__version__)):
-            os.remove("{}/{}.not.finished".format(self.directory,__version__))
+        if os.path.isfile("{}/{}.not.finished".format(self.directory, __version__)):
+            os.remove("{}/{}.not.finished".format(self.directory, __version__))
 
         # Remove album art image as it is embedded
         if self.embed_art:

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -71,10 +71,12 @@ class BandcampDownloader:
         path = self.template
 
         if self.no_slugify:
+            path = path.replace("%{genres}", track['genres'])
             path = path.replace("%{artist}", track['artist'])
             path = path.replace("%{album}", track['album'])
             path = path.replace("%{title}", track['title'])
         else:
+            path = path.replace("%{genres}", slugify(track['genres']))
             path = path.replace("%{artist}", slugify(track['artist']))
             path = path.replace("%{album}", slugify(track['album']))
             path = path.replace("%{title}", slugify(track['title']))
@@ -111,6 +113,7 @@ class BandcampDownloader:
         :param album: album dict
         :return: True if successful
         """
+
         for track_index, track in enumerate(album['tracks']):
             track_meta = {
                 "artist": album['artist'],
@@ -120,7 +123,8 @@ class BandcampDownloader:
                 "track": track['track'],
                 # TODO: Find out why the 'lyrics' key seems to vanish.
                 "lyrics": track.get('lyrics', "lyrics unavailable"),
-                "date": album['date']
+                "date": album['date'],
+                "genres": album['genres']
             }
 
             self.num_tracks = len(album['tracks'])


### PR DESCRIPTION
Proposed means of supporting the genre tags in the filepath template. Decisions to revise or affirm: 'core' genres, whether to try variants of those tags, replacement when an album has no core genre tag, separation character.

That's why I didn't mark the commit as a 'fix' or 'resolve', which unfortunately means github didn't bind this pull to issue [#125].