### PR TITLE
Use the popup image instead of the thumbnail

### DIFF
--- a/bandcamp_dl/bandcamp.py
+++ b/bandcamp_dl/bandcamp.py
@@ -158,7 +158,7 @@ class Bandcamp:
         :return: url as str
         """
         try:
-            url = self.soup.find(id='tralbumArt').find_all('img')[0]['src']
+            url = self.soup.find(id='tralbumArt').find_all('a')[0]['href']
             return url
         except None:
             pass


### PR DESCRIPTION
The thumbnail is often 700x700 in resolution, the pop-up image tends
to be 1200x1200.

For use in music libraries, where the album art may be displayed. It's
preferable to fetch the original resolution album art.