### PR TITLE
Robominis download discography

### DIFF
--- a/bandcamp_dl/__main__.py
+++ b/bandcamp_dl/__main__.py
@@ -87,9 +87,7 @@ def main():
     elif arguments['--artist'] and arguments['--track']:
         urls = Bandcamp.generate_album_url(arguments['--artist'], arguments['--track'], "track")
     elif arguments['--artist']:
-        print(__doc__)
-        os.remove(session_file)
-        exit()
+        urls = Bandcamp.generate_all_albums_url(arguments['--artist'])
     else:
         urls = arguments['URL']
 

--- a/bandcamp_dl/bandcamp.py
+++ b/bandcamp_dl/bandcamp.py
@@ -163,6 +163,21 @@ class Bandcamp:
         """
         return f"http://{artist}.bandcamp.com/{page_type}/{slug}"
 
+    @staticmethod
+    def generate_all_albums_url(artist: str) -> list:
+        """Generate a list of album url based on the artist name
+
+        :param artist: artist name
+        :return: list of url as str
+        """
+        discog_url = f"https://{artist}.bandcamp.com/music"
+        response = requests.get(discog_url)
+        soup = BeautifulSoup(response.text, 'html.parser')
+        albums_grid = soup.find('ol', {'id': 'music-grid'})
+        albums_list = BandcampJSON.list_all_albums(albums_grid)
+        albums_list = [f"http://{artist}.bandcamp.com/{a}" for a in albums_list]
+        return albums_list
+    
     def get_album_art(self) -> str:
         """Find and retrieve album art url from page
 

--- a/bandcamp_dl/bandcampjson.py
+++ b/bandcamp_dl/bandcampjson.py
@@ -1,7 +1,7 @@
 import logging
 
 import demjson3
-
+import re
 
 class BandcampJSON:
     def __init__(self, body, debugging: bool = False):

--- a/bandcamp_dl/bandcampjson.py
+++ b/bandcamp_dl/bandcampjson.py
@@ -35,6 +35,17 @@ class BandcampJSON:
         for script in embedded_scripts_raw:
             js_data = self.js_to_json(script)
             self.json_data.append(js_data)
+            
+    @staticmethod
+    def list_all_albums(body, albums=True, tracks=True):
+        albums = body.find_all('li', attrs={'class': 'music-grid-item'})
+        albums = [a.find('a') for a in albums if a.find('a')]
+        albums_url = [a['href'] for a in albums if a.has_attr('href')]
+        if not albums:
+            albums_url = [a for a in albums_url if not re.match(r'/album/.*', a)]
+        if not tracks:
+            albums_url = [a for a in albums_url if not re.match(r'/track/.*', a)]
+        return albums_url
 
     @staticmethod
     def js_to_json(js_data):


### PR DESCRIPTION
Option to download the entire discography of an artist when only passing the '--artist' argument.

Not sure if a 'track' link can appear in the albums page of the artist but i added options to filter out tracks and albums to the list_all_albums method in the bandcamp.json file just in case it might be useful in the future. These might not be necessary.

Cheers !