### PR TITLE
Add --no-confirm option

### DIFF
--- a/bandcamp_dl/__main__.py
+++ b/bandcamp_dl/__main__.py
@@ -30,6 +30,7 @@ Options:
     -a --ascii-only         Only allow ASCII chars (北京 (capital of china) -> bei-jing-capital-of-china)
     -k --keep-spaces        Retain whitespace in filenames
     -u --keep-upper         Retain uppercase letters in filenames
+    --no-confirm            Override confirmation prompts. Use with caution.
 
 """
 """
@@ -120,7 +121,8 @@ def main():
                                                      arguments['--embed-art'], arguments['--no-slugify'],
                                                      arguments['--ok-chars'], arguments['--space-char'],
                                                      arguments['--ascii-only'], arguments['--keep-spaces'],
-                                                     arguments['--keep-upper'], arguments['--debug'], album['url'])
+                                                     arguments['--keep-upper'], arguments['--debug'],
+                                                     arguments['--no-confirm'], album['url'])
             logging.debug("Initiating download process..")
             bandcamp_downloader.start(album)
             # Add a newline to stop prompt mangling

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -21,7 +21,7 @@ from bandcamp_dl.utils.clean_print import print_clean
 
 class BandcampDownloader:
     def __init__(self, template, directory, overwrite, embed_lyrics, grouping, embed_art, no_slugify, ok_chars,
-                 space_char, ascii_only, keep_space, keep_upper, debugging, urls=None):
+                 space_char, ascii_only, keep_space, keep_upper, debugging, no_confirm, urls=None):
         """Initialize variables we will need throughout the Class
 
         :param urls: list of urls
@@ -49,6 +49,7 @@ class BandcampDownloader:
         self.keep_space = keep_space
         self.keep_upper = keep_upper
         self.debugging = debugging
+        self.confirmation_skip = no_confirm
 
     def start(self, album: dict):
         """Start album download process
@@ -58,7 +59,7 @@ class BandcampDownloader:
         if self.debugging:
             logging.basicConfig(level=logging.DEBUG)
 
-        if album['full'] is not True:
+        if not album['full'] and not self.confirmation_skip:
             choice = input("Track list incomplete, some tracks may be private, download anyway? (yes/no): ").lower()
             if choice == "yes" or choice == "y":
                 print("Starting download process.")


### PR DESCRIPTION
This new option allows to skip the confirmation prompt when albums are incomplete and possibly can be used for future things that might include prompting the user for something.

I went with --no-confirm as the long-option name since --yes could be confused with the already existing -y short-option. Most probably this option will be used in scripts, thus I think a medium long option name like that is ok.