### PR TITLE
Add install instructions on Arch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,11 @@ From Wheel
 
 ``brew install bandcamp-dl``
 
+[Arch] From the AUR
+~~~~~~~~~~~~~~~~~~~
+
+``yay -S bandcamp-dl-git``
+
 From Source
 ~~~~~~~~~~~
 


### PR DESCRIPTION
Hi,
I just adopted and fixed the package on the [AUR](https://aur.archlinux.org/packages/bandcamp-dl-git).

This PR add the install instructions for it.