### PR TITLE
Minor fixes and added "Album artist" tag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,8 @@ output file names and directories. Templates can be built using special
 tokens with the format of ``%{artist}``. Here is a list of allowed
 tokens:
 
--  ``artist``: The artist name.
+-  ``trackartist``: The artist name.
+-  ``artist``: The album artist name.
 -  ``album``: The album name.
 -  ``track``: The track number.
 -  ``title``: The track title.

--- a/bandcamp_dl/bandcamp.py
+++ b/bandcamp_dl/bandcamp.py
@@ -109,7 +109,7 @@ class Bandcamp:
             return track_lyrics.text
         else:
             logging.debug(" Lyrics not found..")
-            return "lyrics unavailable"
+            return ""
 
     def all_tracks_available(self) -> bool:
         """Verify that all tracks have a url
@@ -133,6 +133,7 @@ class Bandcamp:
             "duration": track['duration'],
             "track": str(track['track_num']),
             "title": track['title'],
+            "artist": track['artist'],
             "url": None
         }
 
@@ -145,9 +146,8 @@ class Bandcamp:
             track_metadata['url'] = None
 
         if track['has_lyrics'] is not False:
-            if track['lyrics'] is None:
-                track['lyrics'] = "lyrics unavailable"
-            track_metadata['lyrics'] = track['lyrics'].replace('\\r\\n', '\n')
+            if track['lyrics'] is not None:
+                track_metadata['lyrics'] = track['lyrics'].replace('\\r\\n', '\n')
 
         logging.debug(" Track metadata generated..")
         return track_metadata

--- a/bandcamp_dl/deps.txt
+++ b/bandcamp_dl/deps.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.10.0
 demjson3==3.0.5
 docopt-ng==0.8.1
 mutagen==1.45.1
-requests==2.26.0
+requests==2.31.0
 unicode-slugify==0.1.5
 mock==4.0.3
 chardet==4.0.0

--- a/bandcamp_dl/utils/config.py
+++ b/bandcamp_dl/utils/config.py
@@ -63,4 +63,5 @@ def init_config(arguments) -> json or dict:
             f.write("".join(str(arguments).split('\n')))
 
     config = {key: arguments.get(key, config[key]) for key in config}
+    
     return config


### PR DESCRIPTION
Hi, I tried to change the artist tags to make them the same as when downloaded through the bandcamp website, for example:

- an album is by the album artist "A and B", and there are two tracks: "song 1" by "A" and "song 2" by "B
- when downloading from bandcamp's website, the track names stay "song 1" and "song 2", the album artist in both songs is "A and B", the artists are "A" and "B" respectively
- when downloading with upstream bandcamp-dl, the songs are named "A - song 1" and "B - song 2", the album artist is empty, and the artist for both songs are "A and B"

Some music player apps will say that an album has no artist if only the "artist" tags are filled but not "album artist", it's also pretty annoying downloading splits or compilations and having the artists in the track name, instead of the artist tag where they belong.

So, this fork should behave the same as when downloading from bandcamp's website. I've tested it on 3 different cases (single, album by a single artist, album by multiple artists) and so far it seems OK. The changes are:

- put album artist in the "album artist" tag
- put track artist in the "artist" tag if it exists, if not then use album artist
- if an album has multiple artists, don't put artist in the track name (removes first occurrence of a "{Artist} - " string. a little hacky, but I didn't see a track name without an artist name in the JSON...)
- added {trackartist} to the template, and made {artist} use the album artist, so by default albums with multiple artists stay in a single folder named after the album artist
   - it'd be nicer to add {albumartist} and have {artist} mean "track artist" so it's consistent with the usual tag names, but that would mess with people's existing configs...

And some minor things I came across along the way:

- if there isn't a track number, use "1"
    - singles don't seem to have a track numbers on Bandcamp, so they would end up with "None" in the "track" tag. it doesn't cause any real problems to my knowledge, but for example eyeD3 throws warnings when it sees it
- if the "-e" option is used but a track doesn't have lyrics, keep them blank instead of writing "lyrics unavailable" in the metadata (is there a reason for why it does that?)
- if a template fails to load from config (it happened to me once, but I don't know why) put files in current folder instead of trying to put them in the config folder, which would create a folder called "None"

PS: sorry in advance if I'm doing something wrong, it's my first time making a pull request :-)