### PR TITLE
Drop mock dep, use unittest.mock

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,8 +191,6 @@ Dependencies
 -  `Docopt <https://pypi.python.org/pypi/docopt>`_ - CLI help
 -  `Six <https://pypi.python.org/pypi/six>`_ - Python 2-3 compatibility
 -  `Unidecode <https://pypi.python.org/pypi/unidecode>`_ - ASCII representation of Unicode text
--  `Mock <https://pypi.python.org/pypi/mock>`_ - Library for Python unit testing
--  `PBR <https://pypi.python.org/pypi/pbr>`_ - Setuptools injection library required by Mock
 
 Copyright
 ---------

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -11,7 +11,7 @@ from mutagen.id3._frames import APIC
 from bandcamp_dl.utils.unicode_slugify import slugify
 
 if not sys.version_info[:2] == (3, 6):
-    import mock
+    import unittest.mock
     from bandcamp_dl.utils import requests_patch
 
 from bandcamp_dl.__init__ import __version__
@@ -163,7 +163,7 @@ class BandcampDownloader:
             while True:
                 try:
                     if not sys.version_info[:2] == (3, 6):
-                        with mock.patch('http.client.parse_headers', requests_patch.parse_headers):
+                        with unittest.mock.patch('http.client.parse_headers', requests_patch.parse_headers):
                             r = self.session.get(track['url'], headers=self.headers, stream=True)
                     else:
                         r = self.session.get(track['url'], headers=self.headers, stream=True)
@@ -253,18 +253,18 @@ class BandcampDownloader:
                 audio["APIC"] = APIC(encoding=3, mime='image/jpeg', type=3, desc='Cover', data=cover_bytes)
         audio.save()
 
-        audio = EasyMP3(filepath)   
-        
+        audio = EasyMP3(filepath)
+
         if meta['track'].isdigit():
             audio["tracknumber"] = meta['track']
         else:
             audio["tracknumber"] = '1'
-            
+
         if meta['artist'] is not None:
             audio["artist"] = meta['artist']
         else:
             audio["artist"] = meta['albumartist']
-        
+
         audio["title"] = meta["title"]
         audio["albumartist"] = meta['albumartist']
         audio["album"] = meta['album']

--- a/bandcamp_dl/deps.txt
+++ b/bandcamp_dl/deps.txt
@@ -4,5 +4,4 @@ docopt-ng==0.8.1
 mutagen==1.45.1
 requests==2.31.0
 unicode-slugify==0.1.5
-mock==4.0.3
 chardet==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ docopt-ng==0.8.1
 mutagen==1.45.1
 requests==2.31.0
 unicode-slugify==0.1.5
-mock==4.0.3
 chardet==4.0.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'mutagen',
         'requests',
         'unicode-slugify',
-        'mock',
         'chardet',
     ],
     extras_require={


### PR DESCRIPTION
[`unittest.mock`](https://docs.python.org/3/library/unittest.mock.html) has been in the Python standard library since Python 3.3, and this project only supports Python 3.4 and above. The `mock` package is identical to `unittest.mock` in the standard library -- in fact, it only still exists as a backport for earlier versions of Python (before 3.3).