### PR TITLE
Hack to make full discography work

### DIFF
--- a/bandcamp_dl/__main__.py
+++ b/bandcamp_dl/__main__.py
@@ -112,6 +112,8 @@ def main():
     album_list = []
 
     for url in urls:
+        if "/album/" not in url and "/track/" not in url:
+            continue
         logger.debug("\n\tURL: %s", url)
         album_list.append(bandcamp.parse(url, not arguments.no_art, arguments.embed_lyrics,
                                          arguments.debug))


### PR DESCRIPTION
In my testing the `urls` list often (always?) contains a top-level url of the artist without any albums or tracks, and is the first in the list, causing `bandcamp-dl` to immediately fail.

This could potentially be fixed in get_full_discography(), but I'm not that good at python.