### PR TITLE
Add WOAF Metadata

### DIFF
--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -132,7 +132,8 @@ class BandcampDownloader:
                           "track": track['track'],
                           # TODO: Find out why the 'lyrics' key seems to vanish.
                           "lyrics": track.get('lyrics', ""),
-                          "date": album['date']}
+                          "date": album['date'],
+                          "url": album['url']}
 
             self.num_tracks = len(album['tracks'])
             self.track_num = track_index + 1
@@ -236,6 +237,7 @@ class BandcampDownloader:
         audio = mp3.MP3(filepath)
         audio.delete()
         audio["TIT2"] = id3._frames.TIT2(encoding=3, text=["title"])
+        audio["WOAF"] = id3._frames.WOAF(url=meta["url"])
         audio.save(filename=None, v1=2)
 
         audio = mp3.MP3(filepath)


### PR DESCRIPTION
Adds the ID3v2 "WOAF" (‘Official audio file webpage’) metadata tag to each file, set to the bandcamp album webpage URL.