### PR TITLE
fix pyproject.toml for installation with setuptools and poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "requests >= 2.32.3",
     "unicode-slugify >= 0.1.5"
 ]
+dynamic = ["license", "keywords", "optional-dependencies"]
 
 [project.scripts]
 bandcamp-dl = "bandcamp_dl.__main__:main"


### PR DESCRIPTION
Without it I got errors while trying to install `bandcamp-dl` as a dependency (in https://github.com/gpchelkin/scdlbot)

```
poetry update --with main,dev,docs
Updating dependencies
Resolving dependencies... (12.4s)

Package operations: 0 installs, 1 update, 0 removals

  - Updating bandcamp-downloader (0.0.15 4eae79a -> 0.0.15 cdf24c0): Failed

  ChefBuildError

  Backend subprocess exited when trying to invoke get_requires_for_build_wheel
  
  /tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:71: _MissingDynamic: `license` defined outside of `pyproject.toml` is ignored.
  !!
  
          ********************************************************************************
          The following seems to be defined outside of `pyproject.toml`:
  
          `license = 'Unlicense'`
  
          According to the spec (see the link below), however, setuptools CANNOT
          consider this value unless `license` is listed as `dynamic`.
  
          https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table
  
          To prevent this problem, you can list `license` under `dynamic` or alternatively
          remove the `[project]` table from your file and rely entirely on other means of
          configuration.
          ********************************************************************************
  
  !!
    _handle_missing_dynamic(dist, project_table)
  /tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:71: _MissingDynamic: `keywords` defined outside of `pyproject.toml` is ignored.
  !!
  
          ********************************************************************************
          The following seems to be defined outside of `pyproject.toml`:
  
          `keywords = ['bandcamp', 'downloader', 'music', 'cli', 'albums', 'dl']`
  
          According to the spec (see the link below), however, setuptools CANNOT
          consider this value unless `keywords` is listed as `dynamic`.
  
          https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table
  
          To prevent this problem, you can list `keywords` under `dynamic` or alternatively
          remove the `[project]` table from your file and rely entirely on other means of
          configuration.
          ********************************************************************************
  
  !!
    _handle_missing_dynamic(dist, project_table)
  /tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:71: _MissingDynamic: `optional-dependencies` defined outside of `pyproject.toml` is ignored.
  !!
  
          ********************************************************************************
          The following seems to be defined outside of `pyproject.toml`:
  
          `optional-dependencies = {'dev': ['requests-cache', 'pytest']}`
  
          According to the spec (see the link below), however, setuptools CANNOT
          consider this value unless `optional-dependencies` is listed as `dynamic`.
  
          https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table
  
          To prevent this problem, you can list `optional-dependencies` under `dynamic` or alternatively
          remove the `[project]` table from your file and rely entirely on other means of
          configuration.
          ********************************************************************************
  
  !!
    _handle_missing_dynamic(dist, project_table)
  /tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:78: SetuptoolsWarning: `install_requires` overwritten in `pyproject.toml` (dependencies)
    corresp(dist, value, root_dir)
  Traceback (most recent call last):
    File "/home/gpchelkin/.local/share/pypoetry/venv/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in <module>
      main()
    File "/home/gpchelkin/.local/share/pypoetry/venv/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 357, in main
      json_out["return_val"] = hook(**hook_input["kwargs"])
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/home/gpchelkin/.local/share/pypoetry/venv/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 134, in get_requires_for_build_wheel
      return hook(config_settings)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
      return self._get_build_requires(config_settings, requirements=[])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
      self.run_setup()
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 318, in run_setup
      exec(code, locals())
    File "<string>", line 11, in <module>
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/__init__.py", line 117, in setup
      return distutils.core.setup(**attrs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 157, in setup
      dist.parse_config_files()
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/_virtualenv.py", line 22, in parse_config_files
      result = old_parse_config_files(self, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/dist.py", line 608, in parse_config_files
      pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py", line 72, in apply_configuration
      return _apply(dist, config, filepath)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 52, in apply
      _apply_project_table(dist, config, root_dir)
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 78, in _apply_project_table
      corresp(dist, value, root_dir)
    File "/tmp/tmpi5doviyc/.venv/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 181, in _license
      _set_config(dist, "license", val["text"])
                                   ~~~^^^^^^^^
  KeyError: 'text'
  

  at ~/.local/share/pypoetry/venv/lib/python3.11/site-packages/poetry/installation/chef.py:164 in _prepare
      160│ 
      161│                 error = ChefBuildError("\n\n".join(message_parts))
      162│ 
      163│             if error is not None:
    → 164│                 raise error from None
      165│ 
      166│             return path
      167│ 
      168│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
make: *** [Makefile:32: update] Error 1
```