### PR TITLE
add cmd argument --embed-genres to fetch genres

### DIFF
--- a/bandcamp_dl/__main__.py
+++ b/bandcamp_dl/__main__.py
@@ -55,7 +55,7 @@ def main():
                         action='store_true', default=conf.embed_lyrics)
     parser.add_argument('-g', '--group', help='Use album/track Label as iTunes grouping',
                         action='store_true', default=conf.group)
-    parser.add_argument('-r', '--embed-art', help='Use album/track Label as iTunes grouping',
+    parser.add_argument('-r', '--embed-art', help='Embed album art (If available)',
                         action='store_true', default=conf.embed_art)
     parser.add_argument('-y', '--no-slugify', action='store_true', default=conf.no_slugify,
                         help='Disable slugification of track, album, and artist names')
@@ -72,6 +72,8 @@ def main():
                         action='store_true', default=conf.keep_upper)
     parser.add_argument('--no-confirm', help='Override confirmation prompts. Use with caution',
                         action='store_true', default=conf.no_confirm)
+    parser.add_argument('--embed-genres', help='Embed album/track genres',
+                        action='store_true', default=conf.embed_genres)
 
     arguments = parser.parse_args()
     if arguments.version:
@@ -114,7 +116,7 @@ def main():
         if "/album/" not in url and "/track/" not in url:
             continue
         logger.debug("\n\tURL: %s", url)
-        album_list.append(bandcamp.parse(url, not arguments.no_art, arguments.embed_lyrics,
+        album_list.append(bandcamp.parse(url, not arguments.no_art, arguments.embed_lyrics, arguments.embed_genres,
                                          arguments.debug))
 
     for album in album_list:

--- a/bandcamp_dl/bandcamp.py
+++ b/bandcamp_dl/bandcamp.py
@@ -62,13 +62,14 @@ class Bandcamp:
         self.adapter = SSLAdapter(ssl_context=ctx)
         self.session.mount('https://', self.adapter)
 
-    def parse(self, url: str, art: bool = True, lyrics: bool = False,
+    def parse(self, url: str, art: bool = True, lyrics: bool = False, genres: bool = False,
               debugging: bool = False) -> dict or None:
         """Requests the page, cherry-picks album info
 
         :param url: album/track url
         :param art: if True download album art
         :param lyrics: if True fetch track lyrics
+        :param genres: if True fetch track tags
         :param debugging: if True then verbose output
         :return: album metadata
         """
@@ -123,7 +124,8 @@ class Bandcamp:
             "full": False,
             "art": "",
             "date": str(datetime.datetime.strptime(album_release, "%d %b %Y %H:%M:%S GMT").year),
-            "url": url
+            "url": url,
+            "genres": ""
         }
 
         if "track" in page_json['url']:
@@ -135,6 +137,7 @@ class Bandcamp:
             if lyrics:
                 track['lyrics'] = self.get_track_lyrics(f"{artist_url}"
                                                         f"{track['title_link']}#lyrics")
+
             if track['file'] is not None:
                 track = self.get_track_metadata(track)
                 album['tracks'].append(track)
@@ -142,6 +145,8 @@ class Bandcamp:
         album['full'] = self.all_tracks_available()
         if art:
             album['art'] = self.get_album_art()
+        if genres:
+            album['genres'] = ','.join(page_json['keywords'])
 
         self.logger.debug(" Album generated..")
         self.logger.debug(" Album URL: %s", album['url'])

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -143,7 +143,8 @@ class BandcampDownloader:
                           "track": track['track'],
                           # TODO: Find out why the 'lyrics' key seems to vanish.
                           "lyrics": track.get('lyrics', ""),
-                          "date": album['date']}
+                          "date": album['date'],
+                          "genres": album['genres'],}
 
             self.num_tracks = len(album['tracks'])
             self.track_num = track_index + 1
@@ -261,6 +262,8 @@ class BandcampDownloader:
                 cover_bytes = cover_img.read()
                 audio["APIC"] = id3._frames.APIC(encoding=3, mime='image/jpeg', type=3,
                                                  desc='Cover', data=cover_bytes)
+        if self.config.embed_genres:
+            audio["TCON"] = id3._frames.TCON(encoding=3, text=meta['genres'])
         audio.save()
 
         audio = mp3.EasyMP3(filepath)
@@ -274,7 +277,6 @@ class BandcampDownloader:
             audio["artist"] = meta['artist']
         else:
             audio["artist"] = meta['albumartist']
-
         audio["title"] = meta["title"]
         audio["albumartist"] = meta['albumartist']
         audio["album"] = meta['album']

--- a/bandcamp_dl/config.py
+++ b/bandcamp_dl/config.py
@@ -33,7 +33,8 @@ class Config(dict):
                  "keep_spaces": False,
                  "keep_upper": False,
                  "no_confirm": False,
-                 "debug": False}
+                 "debug": False,
+                 "embed_genres": False}
 
     def __init__(self, dict_=None):
         if dict_ is None:


### PR DESCRIPTION
user can use --embed-genres argument to embed album/track genres, the feature works for album/track/getFullDiscography

this requirment came from: 
I use a local music player to play the downloaded music, this software has a feature that it can automatically place music into the corresponding playlists you've created based on the genres of music. (this software monitors the changes of music files in the certain directory you've set before)

For example: 
**if I created a jazz smart playlist, then all songs with "jazz" genre in their metadata will be automatically added to this playlists.**  This is especially helpful for songs with many genres, saving a lot of time from having to drag and drop music into the corresponding genre playlists manually.

the last: I find there is a little mistake of this line:
```python
parser.add_argument('-r', '--embed-art', help='Use album/track Label as iTunes grouping'
```
and I correct it~