### PR TITLE
Expand case conversion modes for slugified content

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,8 @@ Options
                                 [default: -]
         -a --ascii-only         Only allow ASCII chars (北京 (capital of china) -> bei-jing-capital-of-china)
         -k --keep-spaces        Retain whitespace in filenames
-        -u --keep-upper         Retain uppercase letters in filenames
+        -x {lower,upper,camel,none}, --case-convert {lower,upper,camel,none}
+                                Specify the char case conversion logic, default: lower
 
 Filename Template
 -----------------

--- a/bandcamp_dl/__main__.py
+++ b/bandcamp_dl/__main__.py
@@ -68,8 +68,10 @@ def main():
                         default=conf.ascii_only)
     parser.add_argument('-k', '--keep-spaces', help='Retain whitespace in filenames',
                         action='store_true', default=conf.keep_spaces)
-    parser.add_argument('-u', '--keep-upper', help='Retain uppercase letters in filenames',
-                        action='store_true', default=conf.keep_upper)
+    parser.add_argument('-x', '--case-convert', help=f'Specify the char case conversion logic, '
+                        f'default: {conf.case_mode}', default=conf.case_mode, dest='case_mode',
+                        choices=[config.CASE_LOWER, config.CASE_UPPER, config.CASE_CAMEL,
+                        config.CASE_NONE]) 
     parser.add_argument('--no-confirm', help='Override confirmation prompts. Use with caution',
                         action='store_true', default=conf.no_confirm)
     parser.add_argument('--embed-genres', help='Embed album/track genres',

--- a/bandcamp_dl/config.py
+++ b/bandcamp_dl/config.py
@@ -52,7 +52,7 @@ class Config(dict):
                     # change hyphen with undersore
                     user_config = {k.replace('-', '_'): v for k, v in user_config.items()}
                     # overwrite defaults with user provided config
-                    self.update_with_dict(user_config)
+                    self._update_with_dict(user_config)
                 except json.JSONDecodeError:
                     # NOTE: we don't have logger yet
                     sys.stderr.write(f"Malformed configuration file `{CONFIG_PATH}'. Check json syntax.\n")
@@ -63,7 +63,7 @@ class Config(dict):
                 json.dump(conf, fobj)
             sys.stderr.write(f"Configuration has been written to `{CONFIG_PATH}'.\n")
 
-    def update_with_dict(self, dict_):
+    def _update_with_dict(self, dict_):
         for key, val in dict_.items():
             if key not in self:
                 continue

--- a/bandcamp_dl/config.py
+++ b/bandcamp_dl/config.py
@@ -49,7 +49,7 @@ class Config(dict):
             with pathlib.Path.open(CONFIG_PATH) as fobj:
                 try:
                     user_config = json.load(fobj)
-                    # change hyphen with undersore
+                    # change hyphen with underscore
                     user_config = {k.replace('-', '_'): v for k, v in user_config.items()}
                     # overwrite defaults with user provided config
                     self._update_with_dict(user_config)

--- a/bandcamp_dl/config.py
+++ b/bandcamp_dl/config.py
@@ -10,6 +10,10 @@ from bandcamp_dl import __version__
 TEMPLATE = '%{artist}/%{album}/%{track} - %{title}'
 OK_CHARS = '-_~'
 SPACE_CHAR = '-'
+CASE_LOWER = 'lower'
+CASE_UPPER = 'upper'
+CASE_CAMEL = 'camel'
+CASE_NONE = 'none'
 USER_HOME = pathlib.Path.home()
 # For Linux/BSD https://www.freedesktop.org/wiki/Software/xdg-user-dirs/
 # For Windows ans MacOS .appname is fine
@@ -33,7 +37,7 @@ class Config(dict):
                  "space_char": SPACE_CHAR,
                  "ascii_only": False,
                  "keep_spaces": False,
-                 "keep_upper": False,
+                 "case_mode": CASE_LOWER,
                  "no_confirm": False,
                  "debug": False,
                  "embed_genres": False}
@@ -92,12 +96,17 @@ class Config(dict):
            true / false to indicate whether or not this key was
            supported"""
         migration_type = migration_key = migration_val = None
-        if key == "case_mode":
+        if key == "keep_upper":
+            # forward migration
+            migration_type = OPTION_MIGRATION_FORWARD
+            migration_key = "case_mode"
+            migration_val = self.case_mode = CASE_NONE if val else CASE_LOWER
+        elif key == "case_mode":
             # reverse migration
             migration_type = OPTION_MIGRATION_REVERSE
             migration_key = "keep_upper"
-            migration_val = self.keep_upper = False if val == "lower" else True
-            if val in ["upper", "camel"]:
+            migration_val = self.keep_upper = False if val == CASE_LOWER else True
+            if val in [CASE_UPPER, CASE_CAMEL]:
                 sys.stderr.write(f"Warning, lossy reverse migration, new value '{val}' is not backwards compatible\n")
         if migration_type:
             sys.stderr.write(f"{migration_type.capitalize()} migration of config option: '{key}={val}' -> " \

--- a/bandcamp_dl/config.py
+++ b/bandcamp_dl/config.py
@@ -14,6 +14,8 @@ USER_HOME = pathlib.Path.home()
 # For Linux/BSD https://www.freedesktop.org/wiki/Software/xdg-user-dirs/
 # For Windows ans MacOS .appname is fine
 CONFIG_PATH = USER_HOME / (".config" if os.name == "posix" else ".bandcamp-dl") / "bandcamp-dl.json"
+OPTION_MIGRATION_FORWARD = "forward"
+OPTION_MIGRATION_REVERSE = "reverse"
 
 
 class Config(dict):
@@ -46,13 +48,21 @@ class Config(dict):
 
     def _read_write_config(self):
         if CONFIG_PATH.exists():
-            with pathlib.Path.open(CONFIG_PATH) as fobj:
+            with pathlib.Path.open(CONFIG_PATH, 'r+') as fobj:
                 try:
                     user_config = json.load(fobj)
                     # change hyphen with underscore
                     user_config = {k.replace('-', '_'): v for k, v in user_config.items()}
                     # overwrite defaults with user provided config
-                    self._update_with_dict(user_config)
+                    if self._update_with_dict(user_config) or \
+                      set(user_config.keys()).difference(set(self.keys())) :
+                        # persist migrated options, removal of unsupported options, or missing
+                        # options with their defaults
+                        sys.stderr.write(f"Modified configuration has been written to "
+                                         f"`{CONFIG_PATH}'.\n")
+                        fobj.seek(0)  # r/w mode
+                        fobj.truncate()  # r/w mode
+                        json.dump({k: v for k, v in self.items()}, fobj)
                 except json.JSONDecodeError:
                     # NOTE: we don't have logger yet
                     sys.stderr.write(f"Malformed configuration file `{CONFIG_PATH}'. Check json syntax.\n")
@@ -64,7 +74,34 @@ class Config(dict):
             sys.stderr.write(f"Configuration has been written to `{CONFIG_PATH}'.\n")
 
     def _update_with_dict(self, dict_):
+        """update this config instance with the persisted key-value
+           set, migrating or dropping any unknown options and returning
+           true when the underlying config needs updating"""
+        modified = False
         for key, val in dict_.items():
             if key not in self:
+                modified = True
+                if not self._migrate_option(key, val):
+                    sys.stderr.write(f"Dropping unknown config option '{key}={val}'\n")
                 continue
             self[key] = val
+
+    def _migrate_option(self, key, val):
+        """where supported, migrate legacy options and their values
+           to update this config instance's new option, returning
+           true / false to indicate whether or not this key was
+           supported"""
+        migration_type = migration_key = migration_val = None
+        if key == "case_mode":
+            # reverse migration
+            migration_type = OPTION_MIGRATION_REVERSE
+            migration_key = "keep_upper"
+            migration_val = self.keep_upper = False if val == "lower" else True
+            if val in ["upper", "camel"]:
+                sys.stderr.write(f"Warning, lossy reverse migration, new value '{val}' is not backwards compatible\n")
+        if migration_type:
+            sys.stderr.write(f"{migration_type.capitalize()} migration of config option: '{key}={val}' -> " \
+                             f"'{migration_key}={migration_val}'\n")
+            return True
+        else:
+            return False


### PR DESCRIPTION
For your consideration. Regurgitating the single commit:
```
- Facilitates additional 'upper' and 'camel' case conversion modes when slugification is enabled
- Defaulting to mode 'lower' in order to maintain backward compatibility
- Removes the existing '-u' / '--keep-upper' option as its functionality is entirely consumed by this new option. The direct replacement being '-x none' / '--case-convert=none'
```
All modes appear to work as expected. modifying the mozilla _slugify_ package was never going to happen (this end) so the only real change is the couple of lines in the `slugify_preset()` and the coaxing / massaging of the existing -> new args. My only qualm is  how it looks - 'slighty nasty' - I wonder on your tolerance on cmdline opt cleanliness, yes it's 'pythonic' (I assume given the stdlib parser) but 'man does it look ugly':

```
  -k, --keep-spaces     Retain whitespace in filenames
  -x {lower,upper,camel,none}, --case-convert {lower,upper,camel,none}
                        Specify the char case conversion logic, default: lower
  --no-confirm          Override confirmation prompts. Use with caution
  --embed-genres        Embed album/track genres
```
ps. having grepped for instances of `--keep-upper` that I needed to replace, I noted that the README.rst has no reference to the last two (assuming newest) options(?!) `--no-confirm` / `--embed-genres`, perhaps they should be added for completeness 