### PR TITLE
Download processing, fix album art removal

### DIFF
--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -226,7 +226,7 @@ class BandcampDownloader:
             os.remove(f"{self.config.base_dir}/{__version__}.not.finished")
 
         # Remove album art image as it is embedded
-        if self.config.embed_art:
+        if self.config.embed_art and hasattr(self, "album_art"):
             os.remove(self.album_art)
 
         return True


### PR DESCRIPTION
Example URL / call:
```
> bandcamp-dl --embed-art https://grimesmusic.bandcamp.com/album/darkbloom
Track list incomplete, some tracks may be private, download anyway? (yes/no): yes
Starting download process.
```
with error:
```
Traceback (most recent call last):
  File "/home/build/bandcamp-downloader/venv/bin/bandcamp-dl", line 8, in <module>
    sys.exit(main())
  File "/home/build/bandcamp-downloader/git/bandcamp_dl/__main__.py", line 134, in main
    bandcamp_downloader.start(album)
  File "/home/build/bandcamp-downloader/git/bandcamp_dl/bandcampdownloader.py", line 47, in start
    self.download_album(album)
  File "/home/build/bandcamp-downloader/git/bandcamp_dl/bandcampdownloader.py", line 230, in download_album
    os.remove(self.album_art)
AttributeError: 'BandcampDownloader' object has no attribute 'album_art'
```
When embedding is requested, only remove downloaded album art where it exists