### PR TITLE
Add --truncate-album and --truncate-track args to avoid long filenames

### DIFF
--- a/bandcamp_dl/__main__.py
+++ b/bandcamp_dl/__main__.py
@@ -78,6 +78,11 @@ def main():
                         action='store_true', default=conf.no_confirm)
     parser.add_argument('--embed-genres', help='Embed album/track genres',
                         action='store_true', default=conf.embed_genres)
+    parser.add_argument('--truncate-album', metavar='LENGTH', type=int, default=0,
+                        help='Truncate album title to a maximum length. 0 for no limit.')
+    parser.add_argument('--truncate-track', metavar='LENGTH', type=int, default=0,
+                        help='Truncate track title to a maximum length. 0 for no limit.')
+
 
     arguments = parser.parse_args()
     if arguments.version:

--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -147,12 +147,20 @@ class BandcampDownloader:
                           "url": album['url'],
                           "genres": album['genres']}
 
+            path_meta = track_meta.copy()
+
+            if self.config.truncate_album > 0 and len(path_meta['album']) > self.config.truncate_album:
+                path_meta['album'] = path_meta['album'][:self.config.truncate_album]
+
+            if self.config.truncate_track > 0 and len(path_meta['title']) > self.config.truncate_track:
+                path_meta['title'] = path_meta['title'][:self.config.truncate_track]
+
             self.num_tracks = len(album['tracks'])
             self.track_num = track_index + 1
 
-            filepath = self.template_to_path(track_meta, self.config.ascii_only,
-                                             self.config.ok_chars, self.config.space_char,
-                                             self.config.keep_spaces, self.config.case_mode)
+            filepath = self.template_to_path(path_meta, self.config.ascii_only,
+                                            self.config.ok_chars, self.config.space_char,
+                                            self.config.keep_spaces, self.config.case_mode)
             filepath = filepath + ".tmp"
             filename = filepath.rsplit('/', 1)[1]
             dirname = self.create_directory(filepath)

--- a/bandcamp_dl/config.py
+++ b/bandcamp_dl/config.py
@@ -41,7 +41,9 @@ class Config(dict):
                  "no_confirm": False,
                  "debug": False,
                  "embed_genres": False,
-                 "cover_quality": 0}
+                 "cover_quality": 0,
+                 "truncate_album": 0,
+                 "truncate_track": 0}
 
     def __init__(self, dict_=None):
         if dict_ is None:


### PR DESCRIPTION
Added feature from #267, tested with the albums provided in the issue and it seems to work fine 
```bash
--truncate-track 100 --truncate-album 100 -x none --keep-spaces --embed-art --embed-lyrics --template "%{artist}/%{album}/%{track} - %{title}" https://elizabethveldon.bandcamp.com/album/and-if-any-question-why-we-lived-we-will-reply-for-the-one-million-acts-of-kindness-we-could-bestow-the-fragments-of-compassion-the-love-and-the-hope-of-easing-the-pain-of-others-for-this-and-a-m https://elizabethveldon.bandcamp.com/album/each-performance-is-a-fresh-improvisation-a-new-attempt-to-define-a-language-for-your-instrument-a-new-set-of-gestures-which-builds-upon-but-does-not-seek-to-replicate-each-performance-and-each-s https://elizabethveldon.bandcamp.com/album/then-i-think-of-all-the-women-who-have-gone-before-me-taken-male-names-hidden-themselves-in-the-anonymity-of-institutions-the-safety-of-academia-and-i-think-of-the-waste-the-loss-and-my-heart-bre
```
Saved as
```
└───elizabeth veldon
    ├───and if any question why we lived we will reply for the one million acts of kindness we could bestow
    ├───each performance is a fresh improvisation a new attempt to define a language for your instrument a
    └───then I think of all the women who have gone before me taken male names hidden themselves in the an
```
Maybe the name is not the best one but I couldn't think of anything else that wouldn't be annoyingly long