### PR TITLE
Fixed no-slugify by stringifying replacement

### DIFF
--- a/bandcamp_dl/bandcampdownloader.py
+++ b/bandcamp_dl/bandcampdownloader.py
@@ -101,7 +101,7 @@ class BandcampDownloader:
                 track['track'] = str(track['track']).zfill(2)
 
             if self.config.no_slugify:
-                replacement = track.get(key, "")
+                replacement = str(track.get(key, ""))
             else:
                 replacement = slugify_preset(track.get(key, ""))
 


### PR DESCRIPTION
When using the `no_slugify` option, a `TypeError` is raised because of the `album_id` being an int. Guess it would be the same for `track_id`.

Example using  -y flag:
```python
Traceback (most recent call last):
  File "/usr/bin/bandcamp-dl", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/lib/python3.13/site-packages/bandcamp_dl/__main__.py", line 156, in main
    bandcamp_downloader.start(album)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/usr/lib/python3.13/site-packages/bandcamp_dl/bandcampdownloader.py", line 54, in start
    self.download_album(album)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/usr/lib/python3.13/site-packages/bandcamp_dl/bandcampdownloader.py", line 166, in download_album
    filepath = self.template_to_path(path_meta, self.config.ascii_only,
                                    self.config.ok_chars, self.config.space_char,
                                    self.config.keep_spaces, self.config.case_mode)
  File "/usr/lib/python3.13/site-packages/bandcamp_dl/bandcampdownloader.py", line 108, in template_to_path
    path = path.replace(f'%{{{token}}}', replacement)
TypeError: replace() argument 2 must be str, not int
```
